### PR TITLE
[all] suppression des checkboxs GFM

### DIFF
--- a/.github/ISSUE_TEMPLATE/l-equipe-propose-propose-un-nouveau-standard.md
+++ b/.github/ISSUE_TEMPLATE/l-equipe-propose-propose-un-nouveau-standard.md
@@ -15,8 +15,8 @@ l'importance du standard, le pourquoi du comment.
 Pour savoir si le standard est bien observé, proposez ici une liste de
 vérifications à effectuer :
 
-- [ ] souquer les artibuses ;
-- [ ] etc.
+- souquer les artibuses ;
+- etc.
 
 ## Ressources
 

--- a/accessibilite/l-equipe-a-identifie-ses-problematiques-d-accessibilite-specifiques.md
+++ b/accessibilite/l-equipe-a-identifie-ses-problematiques-d-accessibilite-specifiques.md
@@ -8,6 +8,6 @@ dataviz, et les applications métier.
 
 ## Critères
 
-- [ ] TODO
+- TODO
 
 ## Ressources

--- a/accessibilite/l-equipe-a-un-plan-d-action-pour-la-mise-en-conformite.md
+++ b/accessibilite/l-equipe-a-un-plan-d-action-pour-la-mise-en-conformite.md
@@ -7,8 +7,8 @@ normes d'accessibilité en vigueur.
 
 ## Critères
 
-- [ ] Un plan d'action détaillé est documenté.
-- [ ] Des échéances claires sont définies pour chaque étape.
+- Un plan d'action détaillé est documenté.
+- Des échéances claires sont définies pour chaque étape.
 
 ## Ressources
 

--- a/accessibilite/l-equipe-a-une-personne-avec-la-competence-front-accessibilite.md
+++ b/accessibilite/l-equipe-a-une-personne-avec-la-competence-front-accessibilite.md
@@ -8,8 +8,8 @@ accessibles à tous.
 
 ## Critères
 
-- [ ] Une personne est identifiée comme référent accessibilité.
-- [ ] Des formations régulières sont organisées.
+- Une personne est identifiée comme référent accessibilité.
+- Des formations régulières sont organisées.
 
 ## Ressources
 

--- a/accessibilite/le-service-a-publie-ses-obligations-declaratives.md
+++ b/accessibilite/le-service-a-publie-ses-obligations-declaratives.md
@@ -7,9 +7,9 @@ d'accessibilité, le schéma pluriannuel, et le plan d'action.
 
 ## Critères
 
-- [ ] La déclaration d'accessibilité est disponible et à jour.
-- [ ] Le schéma pluriannuel est documenté et accessible.
-- [ ] Un plan d'action est en place et suivi.
+- La déclaration d'accessibilité est disponible et à jour.
+- Le schéma pluriannuel est documenté et accessible.
+- Un plan d'action est en place et suivi.
 
 ## Ressources
 

--- a/accessibilite/le-service-utilise-le-dsfr.md
+++ b/accessibilite/le-service-utilise-le-dsfr.md
@@ -7,8 +7,8 @@ cohérence visuelle et fonctionnelle avec les autres services publics.
 
 ## Critères
 
-- [ ] Le DSFR est intégré dans le projet.
-- [ ] Les composants DSFR sont utilisés dans les interfaces.
+- Le DSFR est intégré dans le projet.
+- Les composants DSFR sont utilisés dans les interfaces.
 
 ## Ressources
 

--- a/design/l-equipe-a-des-rituels-de-recherche-utilisateurs.md
+++ b/design/l-equipe-a-des-rituels-de-recherche-utilisateurs.md
@@ -7,8 +7,8 @@ recueillir des retours et améliorer le produit.
 
 ## Critères
 
-- [ ] Des sessions de recherche sont planifiées régulièrement.
-- [ ] Les retours utilisateurs sont documentés et analysés.
+- Des sessions de recherche sont planifiées régulièrement.
+- Les retours utilisateurs sont documentés et analysés.
 
 ## Ressources
 

--- a/design/les-parcours-sont-concus-par-une-personne-dont-c-est-le-metier-ux-designer.md
+++ b/design/les-parcours-sont-concus-par-une-personne-dont-c-est-le-metier-ux-designer.md
@@ -7,8 +7,8 @@ utilisateurs pour garantir une expérience fluide et intuitive.
 
 ## Critères
 
-- [ ] Un UX Designer est impliqué dans le projet.
-- [ ] Les parcours utilisateurs sont régulièrement évalués et optimisés.
+- Un UX Designer est impliqué dans le projet.
+- Les parcours utilisateurs sont régulièrement évalués et optimisés.
 
 ## Ressources
 

--- a/eco-conception/le-service-est-frugal-en-fonctionnalites.md
+++ b/eco-conception/le-service-est-frugal-en-fonctionnalites.md
@@ -7,8 +7,8 @@ fonctionnalités superflues qui pourraient compliquer l'expérience utilisateur.
 
 ## Critères
 
-- [ ] Les fonctionnalités sont régulièrement évaluées pour leur pertinence.
-- [ ] Les utilisateurs sont consultés pour valider l'utilité des
+- Les fonctionnalités sont régulièrement évaluées pour leur pertinence.
+- Les utilisateurs sont consultés pour valider l'utilité des
 fonctionnalités.
 
 ## Ressources

--- a/eco-conception/le-service-privilegie-la-low-tech.md
+++ b/eco-conception/le-service-privilegie-la-low-tech.md
@@ -7,8 +7,8 @@ et maximiser l'efficacité.
 
 ## Critères
 
-- [ ] Les solutions low-tech sont privilégiées dans le développement.
-- [ ] L'impact environnemental est régulièrement évalué.
+- Les solutions low-tech sont privilégiées dans le développement.
+- L'impact environnemental est régulièrement évalué.
 
 ## Ressources
 

--- a/qualite-du-support/le-service-n-utilise-pas-des-adresses-mail-ne-pas-repondre-ou-no-reply.md
+++ b/qualite-du-support/le-service-n-utilise-pas-des-adresses-mail-ne-pas-repondre-ou-no-reply.md
@@ -7,8 +7,8 @@ utilisateurs de répondre et d'interagir facilement.
 
 ## Critères
 
-- [ ] Aucune adresse "ne-pas-répondre" n'est utilisée.
-- [ ] Les utilisateurs peuvent facilement contacter le support.
+- Aucune adresse "ne-pas-répondre" n'est utilisée.
+- Les utilisateurs peuvent facilement contacter le support.
 
 ## Ressources
 

--- a/qualite-du-support/les-utilisateurs-peuvent-faire-des-retours-facilement.md
+++ b/qualite-du-support/les-utilisateurs-peuvent-faire-des-retours-facilement.md
@@ -11,8 +11,8 @@ Discussions.
 
 ## Critères
 
-- [ ] Un formulaire de retour est disponible sur le site.
-- [ ] Les retours sont traités rapidement.
+- Un formulaire de retour est disponible sur le site.
+- Les retours sont traités rapidement.
 
 ## Ressources
 

--- a/qualite-logicielle/la-contribution-a-des-communs-numeriques-est-privilegiee.md
+++ b/qualite-logicielle/la-contribution-a-des-communs-numeriques-est-privilegiee.md
@@ -9,6 +9,6 @@ Quand cela est possible, l'équipe contribue aux projets open-source utilisés.
 
 ## Critères
 
-- [ ] Le produit est basé uniquement sur des composants open-source
+- Le produit est basé uniquement sur des composants open-source
 
 ## Ressources

--- a/qualite-logicielle/le-code-est-deploye-frequemment-idealement-en-continu.md
+++ b/qualite-logicielle/le-code-est-deploye-frequemment-idealement-en-continu.md
@@ -7,8 +7,8 @@ jour régulières et une livraison rapide des nouvelles fonctionnalités.
 
 ## Critères
 
-- [ ] Un pipeline CI/CD est en place.
-- [ ] Les déploiements sont automatisés et fréquents.
+- Un pipeline CI/CD est en place.
+- Les déploiements sont automatisés et fréquents.
 
 ## Ressources
 

--- a/qualite-logicielle/le-code-est-ecrit-avec-l-aide-d-un-linter.md
+++ b/qualite-logicielle/le-code-est-ecrit-avec-l-aide-d-un-linter.md
@@ -11,8 +11,8 @@ fichiers.
 
 ## Critères
 
-- [ ] Un linter est en place sur le projet.
-- [ ] L'intégration (CI/CD) intègre le linter.
+- Un linter est en place sur le projet.
+- L'intégration (CI/CD) intègre le linter.
 
 ## Ressources
 

--- a/qualite-logicielle/le-code-est-instrumente-par-des-tests-automatises.md
+++ b/qualite-logicielle/le-code-est-instrumente-par-des-tests-automatises.md
@@ -7,9 +7,9 @@ prévenir les régressions lors des mises à jour.
 
 ## Critères
 
-- [ ] Une suite de tests automatisés est en place.
+- Une suite de tests automatisés est en place.
 - [ ] La suite de tests est intégrée dans la CI/CD du projet
-- [ ] Les tests sont exécutés à chaque déploiement.
+- Les tests sont exécutés à chaque déploiement.
 
 ## Ressources
 

--- a/qualite-logicielle/le-code-source-est-ouvert-y-compris-a-la-contribution-externe.md
+++ b/qualite-logicielle/le-code-source-est-ouvert-y-compris-a-la-contribution-externe.md
@@ -7,8 +7,8 @@ la collaboration et l'amélioration continue.
 
 ## Critères
 
-- [ ] Le code source est accessible publiquement.
-- [ ] Des guidelines de contribution sont disponibles.
+- Le code source est accessible publiquement.
+- Des guidelines de contribution sont disponibles.
 
 ## Ressources
 

--- a/qualite-logicielle/le-produit-a-implemente-un-outil-d-alerte-type-sentry.md
+++ b/qualite-logicielle/le-produit-a-implemente-un-outil-d-alerte-type-sentry.md
@@ -7,8 +7,8 @@ les erreurs en temps réel.
 
 ## Critères
 
-- [ ] Un outil d'alerte est configuré.
-- [ ] Les alertes sont surveillées et traitées rapidement.
+- Un outil d'alerte est configuré.
+- Les alertes sont surveillées et traitées rapidement.
 
 ## Ressources
 

--- a/qualite-logicielle/le-produit-et-la-stack-technique-sont-documentes.md
+++ b/qualite-logicielle/le-produit-et-la-stack-technique-sont-documentes.md
@@ -7,8 +7,8 @@ facilitant la compréhension et la maintenance du projet.
 
 ## Critères
 
-- [ ] Une documentation détaillée est disponible.
-- [ ] La documentation est régulièrement mise à jour.
+- Une documentation détaillée est disponible.
+- La documentation est régulièrement mise à jour.
 
 ## Ressources
 

--- a/qualite-logicielle/les-apis-sont-documentees-avec-un-outil-type-swagger.md
+++ b/qualite-logicielle/les-apis-sont-documentees-avec-un-outil-type-swagger.md
@@ -7,8 +7,8 @@ d'outils comme Swagger pour faciliter leur utilisation par les développeurs.
 
 ## Critères
 
-- [ ] Les APIs sont documentées avec Swagger ou un outil similaire.
-- [ ] La documentation est accessible publiquement.
+- Les APIs sont documentées avec Swagger ou un outil similaire.
+- La documentation est accessible publiquement.
 
 ## Ressources
 

--- a/qualite-logicielle/vcs/.md
+++ b/qualite-logicielle/vcs/.md
@@ -9,8 +9,8 @@ Les produits du réseau doivent être développés en open-source pour encourage
 
 ## Critères
 
-- [ ] Le code est hébergé sur une plateforme publique.
-- [ ] Les contributions externes sont encouragées.
+- Le code est hébergé sur une plateforme publique.
+- Les contributions externes sont encouragées.
 
 ## Ressources
 

--- a/securite/l-equipe-a-entame-une-demarche-sur-monservicesecurise.md
+++ b/securite/l-equipe-a-entame-une-demarche-sur-monservicesecurise.md
@@ -8,8 +8,8 @@ numériques.
 
 ## Critères
 
-- [ ] Une évaluation de sécurité a été réalisée.
-- [ ] Des mesures correctives ont été mises en place.
+- Une évaluation de sécurité a été réalisée.
+- Des mesures correctives ont été mises en place.
 
 ## Ressources
 

--- a/securite/l-equipe-a-mis-en-place-un-outil-d-analyse-statique-du-code-type-sonarcloud.md
+++ b/securite/l-equipe-a-mis-en-place-un-outil-d-analyse-statique-du-code-type-sonarcloud.md
@@ -7,8 +7,8 @@ vulnérabilités et améliorer la qualité du code.
 
 ## Critères
 
-- [ ] SonarCloud est configuré pour le projet.
-- [ ] Les rapports d'analyse sont régulièrement examinés.
+- SonarCloud est configuré pour le projet.
+- Les rapports d'analyse sont régulièrement examinés.
 
 ## Ressources
 

--- a/securite/l-equipe-a-publie-une-politique-de-declaration-des-incidents-de-securite.md
+++ b/securite/l-equipe-a-publie-une-politique-de-declaration-des-incidents-de-securite.md
@@ -7,8 +7,8 @@ place pour garantir une réponse rapide et efficace en cas de problème.
 
 ## Critères
 
-- [ ] La politique est documentée et accessible.
-- [ ] Les membres de l'équipe sont formés à la procédure.
+- La politique est documentée et accessible.
+- Les membres de l'équipe sont formés à la procédure.
 
 ## Ressources
 

--- a/securite/l-equipe-a-realise-un-atelier-d-analyse-de-risques.md
+++ b/securite/l-equipe-a-realise-un-atelier-d-analyse-de-risques.md
@@ -7,8 +7,8 @@ liés au projet, afin de mettre en place des mesures de mitigation.
 
 ## Critères
 
-- [ ] Un rapport d'analyse de risques est disponible.
-- [ ] Des actions correctives ont été définies.
+- Un rapport d'analyse de risques est disponible.
+- Des actions correctives ont été définies.
 
 ## Ressources
 

--- a/securite/l-equipe-initie-une-analyse-d-impact-relative-a-la-protection-des-donnee-si-necessaire.md
+++ b/securite/l-equipe-initie-une-analyse-d-impact-relative-a-la-protection-des-donnee-si-necessaire.md
@@ -8,8 +8,8 @@ réglementations.
 
 ## Critères
 
-- [ ] Une analyse d'impact est documentée.
-- [ ] Les recommandations sont mises en œuvre.
+- Une analyse d'impact est documentée.
+- Les recommandations sont mises en œuvre.
 
 ## Ressources
 

--- a/securite/un-outil-d-analyse-et-de-mise-a-jour-des-dependances-est-configure.md
+++ b/securite/un-outil-d-analyse-et-de-mise-a-jour-des-dependances-est-configure.md
@@ -9,7 +9,7 @@ existent pour automatiser cette veille, comme
 
 ## Critères
 
-- [ ] Un outil d'analyse de sécurité type Dependabot est configuré.
+- Un outil d'analyse de sécurité type Dependabot est configuré.
 
 ## Ressources
 

--- a/transparence/la-roadmap-de-l-equipe-est-publique.md
+++ b/transparence/la-roadmap-de-l-equipe-est-publique.md
@@ -11,8 +11,8 @@ produit et son évolution technique.
 
 ## Critères
 
-- [ ] La roadmap est publiée sur une plateforme accessible.
-- [ ] Les mises à jour sont régulières et transparentes.
+- La roadmap est publiée sur une plateforme accessible.
+- Les mises à jour sont régulières et transparentes.
 
 ## Ressources
 

--- a/transparence/le-produit-a-une-fiche-a-jour-sur-le-site-de-beta.md
+++ b/transparence/le-produit-a-une-fiche-a-jour-sur-le-site-de-beta.md
@@ -12,8 +12,8 @@ la liste des membres, l'URL du code source, etc.
 
 ## Critères
 
-- [ ] La fiche est complète et publiée sur [l'annuaire des réalisations](https://beta.gouv.fr/realisations/)
-- [ ] Les informations sont régulièrement vérifiées et mises à jour.
+- La fiche est complète et publiée sur [l'annuaire des réalisations](https://beta.gouv.fr/realisations/)
+- Les informations sont régulièrement vérifiées et mises à jour.
 
 ## Ressources
 

--- a/transparence/le-produit-communique-sur-son-budget.md
+++ b/transparence/le-produit-communique-sur-son-budget.md
@@ -7,8 +7,8 @@ transparence financière et l'engagement des parties prenantes.
 
 ## Critères
 
-- [ ] Les rapports budgétaires sont publiés annuellement.
-- [ ] Les dépenses et les prévisions sont clairement détaillées.
+- Les rapports budgétaires sont publiés annuellement.
+- Les dépenses et les prévisions sont clairement détaillées.
 
 ## Ressources
 

--- a/transparence/le-produit-suit-ses-bonnes-pratiques-sur-le-dashlord.md
+++ b/transparence/le-produit-suit-ses-bonnes-pratiques-sur-le-dashlord.md
@@ -7,8 +7,8 @@ de qualité, de sécurité et de performance.
 
 ## Critères
 
-- [ ] Dashlord est configuré pour le projet.
-- [ ] Les indicateurs de performance sont régulièrement analysés.
+- Dashlord est configuré pour le projet.
+- Les indicateurs de performance sont régulièrement analysés.
 
 ## Ressources
 

--- a/vie-privee/le-produit-a-des-cgu.md
+++ b/vie-privee/le-produit-a-des-cgu.md
@@ -7,8 +7,8 @@ accessibles, définissant les droits et obligations des utilisateurs.
 
 ## Critères
 
-- [ ] Les CGU sont publiées sur le site.
-- [ ] Les utilisateurs sont informés des mises à jour des CGU.
+- Les CGU sont publiées sur le site.
+- Les utilisateurs sont informés des mises à jour des CGU.
 
 ## Ressources
 

--- a/vie-privee/le-produit-a-des-mentions-legales.md
+++ b/vie-privee/le-produit-a-des-mentions-legales.md
@@ -8,8 +8,8 @@ conditions d'utilisation.
 
 ## Critères
 
-- [ ] Les mentions légales sont accessibles depuis le site.
-- [ ] Les informations sont à jour et conformes aux réglementations.
+- Les mentions légales sont accessibles depuis le site.
+- Les informations sont à jour et conformes aux réglementations.
 
 ## Ressources
 

--- a/vie-privee/le-produit-a-une-politique-de-confidentialite.md
+++ b/vie-privee/le-produit-a-une-politique-de-confidentialite.md
@@ -7,8 +7,8 @@ comment les données des utilisateurs sont collectées, utilisées et protégée
 
 ## Critères
 
-- [ ] La politique de confidentialité est publiée sur le site.
-- [ ] Les utilisateurs sont informés des modifications de la politique.
+- La politique de confidentialité est publiée sur le site.
+- Les utilisateurs sont informés des modifications de la politique.
 
 ## Ressources
 

--- a/vie-privee/les-donnees-de-production-ne-sont-utilisees-qu-en-production.md
+++ b/vie-privee/les-donnees-de-production-ne-sont-utilisees-qu-en-production.md
@@ -8,8 +8,8 @@ production.
 
 ## Critères
 
-- [ ] Des données fictives ou anonymisées sont utilisées en dev/recette.
-- [ ] Les accès aux données de production sont restreints.
+- Des données fictives ou anonymisées sont utilisées en dev/recette.
+- Les accès aux données de production sont restreints.
 
 ## Ressources
 


### PR DESCRIPTION
La checkbox (`[ ]`) fait du sens dans le contexte d'une issue GitHub, ce qui n'est pas forcément la ou en tout cas pas l'unique destination de ces fiches : si on veut exporter les règles dans d'autres outils/formats, c'est plus simple d'avoir les critères sous cette forme.