### PR TITLE
suppression d'une redondance et intégration d'une reference à la loi …

### DIFF
--- a/qualité-logicielle/l-open-source-et-les-communs-numeriques-sont-privilegies.md
+++ b/qualité-logicielle/l-open-source-et-les-communs-numeriques-sont-privilegies.md
@@ -12,7 +12,7 @@ communauté et d'assurer la transparence et la réutilisabilité des
 solutions publiques.
 
 Votre équipe, sauf raison majeure, doit produire du code open-source
-comme le veut la loi pour une république numérique.
+comme le veut la loi pour une République numérique.
 Elle doit aussi privilégier les communs numériques aux solutions propriétaires ou
 non-souveraines dès que possible, comme le veut la stratégie numérique
 de l'État élaborée par la DINUM.


### PR DESCRIPTION
…pour unrépublique numérique

le rappel de l'usage des communs était redondant par rapport aux paragraphe plus haut.

L'open source est obligatoire par la loi