### PR TITLE
Ajout du principe dites le nous une fois

### DIFF
--- a/design/le-service-prevoit-les-cas-d-exclusion-numerique.md
+++ b/design/le-service-prevoit-les-cas-d-exclusion-numerique.md
@@ -34,7 +34,8 @@ Pour y parvenir, trois mesures essentielles s'imposent :
 - L'équipe a identifié qui risque d'être exclu du service numérique
 - Au moins une alternative non-numérique fonctionne (téléphone, guichet,
   partenaires locaux)
-- Le service applique le "[dite le nous une fois](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037313155/)" et évite de demander plusieurs fois les mêmes informations
+- Le service applique le "[dite le nous une fois](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000037313155/)"
+et évite de demander plusieurs fois les mêmes informations
 
 ## Ressources
 


### PR DESCRIPTION
Ajout du principe dite le nous une fois 

Question pourquoi mettre l'inclusion dans le design et non dans l'accessibilité ? Je sais que design inclusif et accessibilité ne sont pas la même chose mais j'ai l'impression qu'elles étaient assez similaires pour les rapprocher dans un même standard