### PR TITLE
qualité du support : relaxe d'un standard

### DIFF
--- a/qualité-du-support/les-utilisateurs-peuvent-faire-des-retours-facilement.md
+++ b/qualité-du-support/les-utilisateurs-peuvent-faire-des-retours-facilement.md
@@ -23,7 +23,6 @@ traitement des réponses avec des délais clairs.
 ## Critères
 
 - Un moyen de contact est visible sur chaque page importante
-- Le service propose au moins deux canaux de contact différents
 - L'équipe utilise une adresse e-mail à laquelle les utilisateurs
   peuvent répondre
 - L'équipe suit et analyse les retours pour améliorer le service


### PR DESCRIPTION
Le critère sur les deux canaux de communication n'est applicable qu'aux services grand public, et il est encore trop tôt pour définir ce périmètre et les mesures associées donc suppression du critère. On avait décidé de le reformuler "au moins une adresse e-mail est disponible" mais c'est implicite dans le critère d'après "l'équipe utilise une adresse e-mail à laquelle les utilisateurs peuvent répondre".

Closes #146.