### PR TITLE
scripts : vérification de la présence de balises HTML

### DIFF
--- a/.scripts/steps.rb
+++ b/.scripts/steps.rb
@@ -13,7 +13,8 @@ Soit('un standard') do
 
   log "\Vérification du standard #{@path}..."
 
-  @parser = StandardParser.new(File.read(@path))
+  @content = File.read(@path)
+  @parser  = StandardParser.new(@content)
 end
 
 Alors('le standard a un titre principal') do
@@ -42,6 +43,9 @@ Alors('tous les liens en ressource sont labelisés avec le titre et le nom de do
   end
 end
 
+Alors('le standard ne contient pas de balises HTML') do
+  expect(@content).not_to match /<[^>]*>/
+end
 
 def links_for_section(section_title)
   section_tree = @parser.content_for_section(section_title)

--- a/vérification-des-standards.feature
+++ b/vérification-des-standards.feature
@@ -9,3 +9,4 @@ Fonctionnalité: Les standards de beta.gouv.fr sont homogènes
     Et la section "Critères" du standard contient uniquement une liste
     Et la section "Ressources" du standard contient uniquement une liste
     Et tous les liens en ressource sont labelisés avec le titre et le nom de domaine
+    Et le standard ne contient pas de balises HTML


### PR DESCRIPTION
Même si les standards font l'object de relectures attentives, rajout d'un garde-fou contre la présence de balises HTML dans les standards.

c.f : https://github.com/betagouv/standards-front/pull/84