### PR TITLE
Update resources in open source document

### DIFF
--- a/qualité-logicielle/l-open-source-et-les-communs-numeriques-sont-privilegies.md
+++ b/qualité-logicielle/l-open-source-et-les-communs-numeriques-sont-privilegies.md
@@ -25,4 +25,4 @@ de l'État élaborée par la DINUM.
 ## Ressources
 
 - [Stratégie numérique de l'État - numerique.gouv.fr](https://www.numerique.gouv.fr/numerique-etat/)
-- [Guide juridique du logiciel libre dans l’administration](https://documentation.ouvert.numerique.gouv.fr/ressources/guide-juridique-du-logiciel-libre-dans-ladministration/)
+- [Guide juridique du logiciel libre dans l’administration - numerique.gouv.fr](https://documentation.ouvert.numerique.gouv.fr/ressources/guide-juridique-du-logiciel-libre-dans-ladministration/)


### PR DESCRIPTION
Following #189 : replaced code.gouv and sillon references with documentation.ouvert.numerique.gouv.fr